### PR TITLE
There is Small Error (Causing Runtime Seg Fault)

### DIFF
--- a/src/c.c
+++ b/src/c.c
@@ -317,7 +317,7 @@ void addComment(const char *file, char *path, const char *comment, bool append) 
 		asprintf(&full, "%s/" COMMENT "/%s.comment", dir, leaf);
 
 		//I dont know why author made full NULL again (Maybe Its a Typo). It gives "c" Runtime Segmentation Fault.
-		//However Code Works Just Fine When Line Below Is Commented. 
+		//However Code Works Just Fine When Line Below Is Commented.
 		//free(full);
 
 		FILE *fp;
@@ -329,6 +329,8 @@ void addComment(const char *file, char *path, const char *comment, bool append) 
 			fprintf(fp, "%s", comment);
 		}
 
+		// Free the pointer full
+		free(full);
 		fclose(fp);
 
 		if (ford == 0) {


### PR DESCRIPTION
![g](https://cloud.githubusercontent.com/assets/9384699/4960703/0dfd9100-66c6-11e4-8fc6-16ab39223f61.png)
I guess on line 299 there is small Error where author tried to free the Pointer \* full which is the main path to our dynamic DB for comments.Which Results in Runtime "Segmentation Fault(Core Dumped)" whenever user tries to  Add/Append a New Comment . However Commenting Line 299 fixes the Problem.
