### PR TITLE
Modify Small Error (Causing Runtime Seg Fault)

### DIFF
--- a/src/c.c
+++ b/src/c.c
@@ -316,7 +316,9 @@ void addComment(const char *file, char *path, const char *comment, bool append) 
 		char *full = NULL;
 		asprintf(&full, "%s/" COMMENT "/%s.comment", dir, leaf);
 
-		free(full);
+		//I dont know why author made full NULL again (Maybe Its a Typo). It gives "c" Runtime Segmentation Fault.
+		//However Code Works Just Fine When Line Below Is Commented.
+		//free(full);
 
 		FILE *fp;
 		if (append) {
@@ -327,6 +329,8 @@ void addComment(const char *file, char *path, const char *comment, bool append) 
 			fprintf(fp, "%s", comment);
 		}
 
+		// Free the pointer full
+		free(full);
 		fclose(fp);
 
 		if (ford == 0) {


### PR DESCRIPTION
![g](https://cloud.githubusercontent.com/assets/9384699/4960863/0e768054-66c8-11e4-95e8-742a2d8fad60.png)
Update To Patch-1 I guess on line 299 there is small Error where author tried to free the Pointer \* full which is the main path to our dynamic DB for comments.Which Results in Runtime "Segmentation Fault(Core Dumped)" whenever user tries to Add/Append a New Comment . However Commenting Line 299 and calling free(full) just before fclose(fp) fixes the Problem.
