### PR TITLE
Simplified the strip() method.

### DIFF
--- a/src/c.c
+++ b/src/c.c
@@ -395,14 +395,19 @@ void put_multiline(const char *s, int width) {
 	}
 }
 
+// Strip trailing new line or tab characters
 void strip(char *s) {
 	char *p2 = s;
 	while(*s != '\0') {
 		if(*s != '\t' && *s != '\n') {
-			*p2++ = *s++;
-		} else {
-			++s;
+			p2 = s;           // Move the second pointer if the current char is non-whitespace(newline/tab)
 		}
+
+        s++;                  // Increment current pointer
 	}
-	*p2 = '\0';
+
+    // It is always true that p < s
+    // at the end, so it is safe to access
+    // p2 + 1
+	*(p2+1) = '\0';
 }


### PR DESCRIPTION
The original code used *p2++ = *s++ which can be achieved
with p2 = s (Simply make p2 point s and increment s). Essentially
p2 points to the last non-whitespace character (\n or \t)

Author: Sanketh Mopuru (sanketh.mopuru@gmail.com)